### PR TITLE
allow password formats to fix KeyError

### DIFF
--- a/opyapi/string_format.py
+++ b/opyapi/string_format.py
@@ -18,6 +18,7 @@ from opyapi.validators.format_validators import (
     validate_format_uri,
     validate_format_url,
     validate_format_uuid,
+    validate_format_password
 )
 
 
@@ -39,6 +40,7 @@ class _StringFormat:
     URI = "uri"
     URL = "url"
     UUID = "uuid"
+    PASSWORD = "password"
 
     def __init__(self):
         self._formats = {
@@ -59,6 +61,7 @@ class _StringFormat:
             self.URI: validate_format_uri,
             self.URL: validate_format_url,
             self.UUID: validate_format_uuid,
+            self.PASSWORD: validate_format_password
         }
 
     def __getitem__(self, format_name: str) -> Callable:

--- a/opyapi/validators/format_validators.py
+++ b/opyapi/validators/format_validators.py
@@ -207,6 +207,13 @@ def validate_format_uuid(value: Any) -> str:
         raise FormatValidationError(expected_format="uuid")
 
 
+def validate_format_password(value: Any) -> str:
+    try:
+        return str(value)
+    except Exception:
+        raise FormatValidationError(expected_format="password")
+
+
 __all__ = [
     "validate_format_boolean",
     "validate_format_bytes",
@@ -225,4 +232,5 @@ __all__ = [
     "validate_format_uri",
     "validate_format_url",
     "validate_format_uuid",
+    "validate_format_password"
 ]

--- a/tests/validators/test_format_validators.py
+++ b/tests/validators/test_format_validators.py
@@ -79,6 +79,8 @@ from opyapi.validators import validate_string_format
         ["b11b1836-ad3e-4944-9c80-eaccdac0487b", StringFormat.UUID],
         ["e643c4f2-f9c1-4287-b465-1e02ba7d902d", StringFormat.UUID],
         ["57766d9b-9ea2-4740-9b26-56dfdd79678a", StringFormat.UUID],
+        ["ThisCouldBeAPassword", StringFormat.PASSWORD],
+        ["!This@Could#Also$Be10A//Password", StringFormat.PASSWORD]
     ],
 )
 def test_pass_valid_format(given_string: str, given_format: str) -> None:


### PR DESCRIPTION
This change aims to allow OAS string with `format: password` to be processed by opyapi.

An issue was opened here:
https://github.com/kodemore/chocs-openapi/issues/3